### PR TITLE
Fix transcription error

### DIFF
--- a/src/epub/text/chapter-3-4.xhtml
+++ b/src/epub/text/chapter-3-4.xhtml
@@ -35,7 +35,7 @@
 			<p>It was Ben Butcher, the able seaman.</p>
 			<p>Polynesia spluttered like an angry firecracker.</p>
 			<p>“This is the last straw,” said she. “The one man in the world we least wanted. Shiver my timbers, what cheek!”</p>
-			<p>“Would it not be, advisable,” suggested Bumpo, “while the varlet is still sleepy, to strike him on the head with some heavy object and push him through a porthole into the sea?”</p>
+			<p>“Would it not be advisable,” suggested Bumpo, “while the varlet is still sleepy, to strike him on the head with some heavy object and push him through a porthole into the sea?”</p>
 			<p>“No. We’d get into trouble,” said Polynesia. “We’re not in Jolliginki now, you know⁠—worse luck!⁠—Besides, there never was a porthole big enough to push that man through. Bring him upstairs to the Doctor.”</p>
 			<p>So we led the man to the wheel where he respectfully touched his cap to the Doctor.</p>
 			<p>“Another stowaway, Sir,” said Bumpo smartly.</p>


### PR DESCRIPTION
Looks like there may have been enough of a smudge on the page scan that it was interpretted as a comma.